### PR TITLE
It was breaking the code editor mode

### DIFF
--- a/resources/assets/js/index.js
+++ b/resources/assets/js/index.js
@@ -28,7 +28,7 @@ class UpdateBody extends Component {
 	componentDidMount() {
 		const wrapper = document.querySelector( '.editor-styles-wrapper' );
 
-		if ( this.props.selectedTemplate ) {
+		if ( wrapper && this.props.selectedTemplate ) {
 			wrapper.classList.add( getCssClassName( this.props.selectedTemplate ) );
 		}
 	}


### PR DESCRIPTION
If you load the page in the code editor mode it would break the whole page because it was trying to access `classList` of undefined.